### PR TITLE
Improve server defaults and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# Here are your Instructions
+# StreamSphere
+
+This project contains a demo video platform with a FastAPI backend and a React frontend.
+
+## Running the backend
+
+The backend requires Python 3.10+.
+
+1. Install dependencies:
+
+```bash
+pip install -r backend/requirements.txt
+```
+
+2. (Optional) create a `.env` file in `backend/` and set `MONGO_URL` and `DB_NAME`.
+   If these variables are not provided the server defaults to `mongodb://localhost:27017`
+   and database `streamsphere`.
+
+3. Start the server:
+
+```bash
+uvicorn backend.server:app --reload
+```
+
+The root endpoint `/` will respond with `{"status": "ok"}` when the server is running.
+
+## Running the frontend
+
+```
+cd frontend
+npm install
+npm start
+```
+
+The frontend will be available on [http://localhost:3000](http://localhost:3000).
+

--- a/backend/server.py
+++ b/backend/server.py
@@ -12,12 +12,13 @@ from datetime import datetime
 
 
 ROOT_DIR = Path(__file__).parent
-load_dotenv(ROOT_DIR / '.env')
+load_dotenv(ROOT_DIR / ".env")
 
 # MongoDB connection
-mongo_url = os.environ['MONGO_URL']
+mongo_url = os.environ.get("MONGO_URL", "mongodb://localhost:27017")
 client = AsyncIOMotorClient(mongo_url)
-db = client[os.environ['DB_NAME']]
+db_name = os.environ.get("DB_NAME", "streamsphere")
+db = client[db_name]
 
 # Create the main app without a prefix
 app = FastAPI()
@@ -26,19 +27,28 @@ app = FastAPI()
 api_router = APIRouter(prefix="/api")
 
 
+# Simple root endpoint for base path
+@app.get("/")
+async def index():
+    return {"status": "ok"}
+
+
 # Define Models
 class StatusCheck(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     client_name: str
     timestamp: datetime = Field(default_factory=datetime.utcnow)
 
+
 class StatusCheckCreate(BaseModel):
     client_name: str
+
 
 # Add your routes to the router instead of directly to app
 @api_router.get("/")
 async def root():
     return {"message": "Hello World"}
+
 
 @api_router.post("/status", response_model=StatusCheck)
 async def create_status_check(input: StatusCheckCreate):
@@ -47,10 +57,12 @@ async def create_status_check(input: StatusCheckCreate):
     _ = await db.status_checks.insert_one(status_obj.dict())
     return status_obj
 
+
 @api_router.get("/status", response_model=List[StatusCheck])
 async def get_status_checks():
     status_checks = await db.status_checks.find().to_list(1000)
     return [StatusCheck(**status_check) for status_check in status_checks]
+
 
 # Include the router in the main app
 app.include_router(api_router)
@@ -66,9 +78,10 @@ app.add_middleware(
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    format=("%(asctime)s - %(name)s - %(levelname)s - %(message)s"),
 )
 logger = logging.getLogger(__name__)
+
 
 @app.on_event("shutdown")
 async def shutdown_db_client():


### PR DESCRIPTION
## Summary
- add root endpoint and fallback DB settings to backend
- document running backend and frontend in README

## Testing
- `flake8 backend/server.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855aa78529c8330b0b7f64f208d3770